### PR TITLE
Update urls.py to be django 1.5+ compatible.

### DIFF
--- a/django_pygments/urls.py
+++ b/django_pygments/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     'django_pygments.views',


### PR DESCRIPTION
django.conf.urls.defaults was deprecated in 1.5 and removed in 1.6.
