### PR TITLE
Add to classifiers supported python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
             'Intended Audience :: Developers',
             'Operating System :: OS Independent',
             'Programming Language :: Python',
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 3',
             'Framework :: Django',
             ],
         )


### PR DESCRIPTION
It will help those people who will do some version compatability checking with officially recomended tool **caniusepython3** which looks exactly into classifiers to detect that an examined lib supports Python 3.

I think it might especially helpful for those who realized that Python 2 EOL is coming :-)

Related to #8.