### PR TITLE
Don't modify Python warning filters

### DIFF
--- a/django_pygments/utils.py
+++ b/django_pygments/utils.py
@@ -1,7 +1,4 @@
-import warnings
-warnings.simplefilter('ignore')
 from pygments.lexers import LEXERS, get_lexer_by_name
-warnings.resetwarnings()
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
 import re


### PR DESCRIPTION
calls to filter and reset warnings have a global effect on projects using the library